### PR TITLE
update to use @google-cloud/storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 "use strict";
 
-let gcloud = require('gcloud');
-
-let storage = gcloud.storage();
+const { Storage } = require('@google-cloud/storage');
 
 const DEFAULT_POLL_TIME = 3 * 1000;
 
@@ -22,18 +20,20 @@ class GCSNotifier {
   }
 
   getLastModified() {
-      let file = storage.bucket(this.bucket).file(this.key);
-      
-      return new Promise(function(resolve, reject){
-        file.get(function(err, file, apiResponse){
-          if (err) {
-            reject(err);
-          }
-          resolve(apiResponse.updated);
-        });
+    let storage = new Storage();
+    let bucket = storage.bucket(this.bucket);
+    let file = bucket.file(this.key);
+
+    return new Promise(function(resolve, reject){
+      file.get(function(err, file, apiResponse){
+        if (err) {
+          reject(err);
+        }
+        resolve(apiResponse.updated);
       });
+    });
   }
-  
+
   getCurrentLastModified() {
     return this.getLastModified()
       .then(LastModified => {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/EmberSherpa/fastboot-gcloud-storage-notifier#readme",
   "dependencies": {
-    "gcloud": "0.32.0"
+    "@google-cloud/storage": "^2.3.0"
   }
 }


### PR DESCRIPTION
The `gcloud` package has been deprecated completely, and causes all sorts of npm/yarn dependency issues when compiling

companion PR: https://github.com/EmberSherpa/fastboot-gcloud-storage-downloader/pull/1

Tested this version and it works now